### PR TITLE
Die Farbe der Schlange variiert je nach Schwierigkeitsgrad

### DIFF
--- a/app/src/main/java/com/example/snake4iu/GameManager.kt
+++ b/app/src/main/java/com/example/snake4iu/GameManager.kt
@@ -7,11 +7,9 @@ import android.graphics.Color
 import android.graphics.Paint
 import android.graphics.Rect
 import android.media.MediaPlayer
-import android.text.TextPaint
 import android.util.AttributeSet
 import android.view.SurfaceHolder
 import android.view.SurfaceView
-import java.util.Objects
 import java.util.Random
 
 class GameManager(context: Context, attributeSet: AttributeSet): SurfaceView(context, attributeSet), SurfaceHolder.Callback {
@@ -227,18 +225,25 @@ class GameManager(context: Context, attributeSet: AttributeSet): SurfaceView(con
         val boardTop = h * 0.1f
         val boardBottom = h * 0.1f + boardSize * pointSize
 
+        val boardBackground = Paint()
+        boardBackground.color = Color.rgb(0,188,212)
+
+        canvas?.drawRect(boardLeft, boardTop, boardRight, boardBottom, boardBackground)
+
         val boardPaint = Paint()
-        boardPaint.color = Color.BLACK
+        boardPaint.color = Color.GRAY
 
         canvas?.drawLine(boardLeft, boardTop, boardLeft, boardBottom, boardPaint)
         canvas?.drawLine(boardLeft, boardTop, boardRight, boardTop, boardPaint)
         canvas?.drawLine(boardLeft, boardBottom, boardRight, boardBottom, boardPaint)
         canvas?.drawLine(boardRight, boardTop, boardRight, boardBottom, boardPaint)
+
+
     }
 
     fun drawApple(canvas: Canvas?) {
             val applePaint = Paint()
-            applePaint.color = Color.GREEN
+            applePaint.color = Color.rgb(255,234,0)
 
             for(i in 0..appleList.size-1) {
                 canvas?.drawRect(getPointRectangle(appleList.get(i)), applePaint)
@@ -264,7 +269,7 @@ class GameManager(context: Context, attributeSet: AttributeSet): SurfaceView(con
 
     fun drawSnake(canvas: Canvas?) {
         val snakePaint = Paint()
-        snakePaint.color = Color.BLUE
+        snakePaint.color = SettingsActivity.snakeColor
 
         for(point: Point in snake) {
             canvas?.drawRect(getPointRectangle(point), snakePaint)

--- a/app/src/main/java/com/example/snake4iu/SettingsActivity.java
+++ b/app/src/main/java/com/example/snake4iu/SettingsActivity.java
@@ -1,5 +1,6 @@
 package com.example.snake4iu;
 
+import android.graphics.Color;
 import android.os.Bundle;
 import android.widget.CompoundButton;
 import android.widget.RadioButton;
@@ -9,6 +10,7 @@ import androidx.appcompat.app.AppCompatActivity;
 public class SettingsActivity extends AppCompatActivity {
 
     public static float speed = 1;
+    public static int snakeColor = Color.rgb(255,165,0);
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -24,6 +26,7 @@ public class SettingsActivity extends AppCompatActivity {
             public void onCheckedChanged(CompoundButton compoundButton, boolean isChecked) {
                 if(isChecked) {
                     speed = 1f;
+                    snakeColor = Color.rgb(255,165,0);
                 }
             }
         });
@@ -33,6 +36,7 @@ public class SettingsActivity extends AppCompatActivity {
             public void onCheckedChanged(CompoundButton compoundButton, boolean isChecked) {
                 if(isChecked) {
                     speed = 2f;
+                    snakeColor = Color.BLACK;
                 }
             }
         });
@@ -41,6 +45,7 @@ public class SettingsActivity extends AppCompatActivity {
             @Override
             public void onCheckedChanged(CompoundButton compoundButton, boolean isChecked) {
                 speed = 3f;
+                snakeColor = Color.RED;
             }
         });
     }


### PR DESCRIPTION
Wählt man Easy, ist die Schlange orange. Wählt man Medium, ist die Schlange schwarz. Wählt man Hard, ist sie rot. Zusätzlich wurde der Hintergrund des Spielfeldes blau eingestellt. Die Äpfel/Inseln sind jetzt gelb (weil sie ja im Grunde genommen Inseln darstellen sollen und keine Äpfel wie bei Snake).