### PR TITLE
Bewegungsrichtung ab Level 2 angepasst

### DIFF
--- a/app/src/main/java/com/example/snake4iu/GameManager.kt
+++ b/app/src/main/java/com/example/snake4iu/GameManager.kt
@@ -127,6 +127,13 @@ class GameManager(context: Context, attributeSet: AttributeSet): SurfaceView(con
                 appleSnacked = 0
                 val initialPoint = Point(Random().nextInt(boardSize - 1), Random().nextInt(boardSize - 1))
                 snake.add(initialPoint)
+                if(initialPoint.x < boardSize / 2) {
+                    movingDirection = Direction.RIGHT
+                    updatedDirection = Direction.RIGHT
+                } else {
+                    movingDirection = Direction.LEFT
+                    updatedDirection = Direction.LEFT
+                }
             }
 
             when (direction) {


### PR DESCRIPTION
Auch ab Level 2 ist es nun so, dass die Schlange, wenn sie in der linken Hälfte des Spielfelds ist nach rechts fährt, und wenn die in der rechten Hälfte ist nach links fährt.