### PR TITLE
GameOver, wenn falsche Inseln eingesammelt

### DIFF
--- a/app/src/main/java/com/example/snake4iu/GameManager.kt
+++ b/app/src/main/java/com/example/snake4iu/GameManager.kt
@@ -112,6 +112,16 @@ class GameManager(context: Context, attributeSet: AttributeSet): SurfaceView(con
                 appleSnacked ++
                 mpApple.start()
             }
+
+            if(snake[0].x == appleList.get(i).x && snake[0].y == appleList.get(i).y && i != appleSnacked) {
+                gameOver = true
+                break
+            }
+        }
+
+        if(gameOver) {
+            (context as SnakeActivity).gameOver()
+            mpDie.start()
         }
 
         if(appleSnacked == appleList.size) {


### PR DESCRIPTION
Wenn man die Inseln in der falschen Reihenfolge einsammelt, geht man jetzt GameOver.