### PR TITLE
Levelanzeige gefixt

### DIFF
--- a/app/src/main/java/com/example/snake4iu/GameManager.kt
+++ b/app/src/main/java/com/example/snake4iu/GameManager.kt
@@ -106,6 +106,8 @@ class GameManager(context: Context, attributeSet: AttributeSet): SurfaceView(con
 
     fun update() {
 
+        (context as SnakeActivity).updateLevel(level)
+
         for(i in 0..appleList.size-1) {
             if (snake[0].x == appleList.get(i).x && snake[0].y == appleList.get(i).y && i == appleSnacked) {
                 appleList.get(i).x = 1000

--- a/app/src/main/java/com/example/snake4iu/SnakeActivity.kt
+++ b/app/src/main/java/com/example/snake4iu/SnakeActivity.kt
@@ -44,7 +44,7 @@ class SnakeActivity : AppCompatActivity() {
     }
 
     fun onGameStart(v: View) {
-        score.text = "0"
+        score.text = "Level 1"
         gameOver.visibility = View.GONE
         gameManager.initGame()
     }


### PR DESCRIPTION
Nach einem GameOver wurde anstatt der Levelanzeige eine "0" angezeigt, bis man im zweiten Level war. Dieser Bug wurde jetzt behoben.