### PR TITLE
Items werden nicht mehr mit ins nächste Level genommen

### DIFF
--- a/app/src/main/java/com/example/snake4iu/GameManager.kt
+++ b/app/src/main/java/com/example/snake4iu/GameManager.kt
@@ -200,6 +200,7 @@ class GameManager(context: Context, attributeSet: AttributeSet): SurfaceView(con
             updateLevel()
             snake.clear()
             generateNewApple()
+            itemSpawn = false
             appleSnacked = 0
             newLevelWait = true
             godMode = false


### PR DESCRIPTION
Wenn ein Item in einem Level nicht eingesammelt wird, ist es jetzt im nächsten Level nicht mehr verfügbar.